### PR TITLE
Add workflow to prepare hotfix branch

### DIFF
--- a/.github/workflows/prepare-hotfix-branch.yaml
+++ b/.github/workflows/prepare-hotfix-branch.yaml
@@ -1,0 +1,15 @@
+name: Prepare Hotfix Branch
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'The tag for which the hotfix should be created'
+        required: true
+        type: string
+
+jobs:
+  call-dashboard-workflow:
+    uses: petersutter/dashboard/.github/workflows/prepare-hotfix-branch.yaml@master
+    with:
+      tag: ${{ inputs.tag }}


### PR DESCRIPTION
## Summary
- add workflow to prepare hotfix branch via dashboard

## Testing
- `go test ./...` (no output, terminated after waiting)

------
https://chatgpt.com/codex/tasks/task_e_689d07eccdfc8320a4b9e0976095e4a9